### PR TITLE
Gemspec fixes

### DIFF
--- a/rdf-n3.gemspec
+++ b/rdf-n3.gemspec
@@ -621,7 +621,6 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<rdf>, ["= 0.3.0.pre"])
-      s.add_runtime_dependency(%q<treetop>, [">= 1.4.0"])
       s.add_development_dependency(%q<rspec>, ["= 1.3.0"])
       s.add_development_dependency(%q<rdf-spec>, [">= 0.2.1"])
       s.add_development_dependency(%q<rdf-rdfxml>, [">= 0.2.1"])
@@ -629,7 +628,6 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<yard>, [">= 0"])
     else
       s.add_dependency(%q<rdf>, ["= 0.3.0.pre"])
-      s.add_dependency(%q<treetop>, [">= 1.4.0"])
       s.add_dependency(%q<rspec>, ["= 1.3.0"])
       s.add_dependency(%q<rdf-spec>, [">= 0.2.1"])
       s.add_dependency(%q<rdf-rdfxml>, [">= 0.2.1"])
@@ -638,7 +636,6 @@ Gem::Specification.new do |s|
     end
   else
     s.add_dependency(%q<rdf>, ["= 0.3.0.pre"])
-    s.add_dependency(%q<treetop>, [">= 1.4.0"])
     s.add_dependency(%q<rspec>, ["= 1.3.0"])
     s.add_dependency(%q<rdf-spec>, [">= 0.2.1"])
     s.add_dependency(%q<rdf-rdfxml>, [">= 0.2.1"])


### PR DESCRIPTION
Remove some removed files from gemspec; fixes a warning on bundle install from git:

rdf-n3 at /usr/local/rvm/gems/ruby-1.9.2-p0/bundler/gems/rdf-n3-5b240f757781 did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  ["lib/rdf/n3/patches/seq.rb", "lib/rdf/n3/reader/n3_grammar.rb", "lib/rdf/n3/reader/n3_grammar.treetop", "lib/rdf/n3/reader/n3_grammar_18.rb", "lib/rdf/n3/reader/n3_grammar_18.treetop"] are not files
