### PR TITLE
Escape backslashes in multi-line literals

### DIFF
--- a/lib/rdf/n3/writer.rb
+++ b/lib/rdf/n3/writer.rb
@@ -400,7 +400,7 @@ module RDF::N3
     # @return [String]
     def quoted(string)
       if string.to_s.match(/[\t\n\r]/)
-        string = string.gsub('\\', '\\\\').gsub('"""', '\\"""')
+        string = string.gsub('\\', '\\\\\\\\').gsub('"""', '\\"""')
         %("""#{string}""")
       else
         "\"#{escaped(string)}\""

--- a/spec/writer_spec.rb
+++ b/spec/writer_spec.rb
@@ -279,6 +279,17 @@ describe RDF::N3::Writer do
         n3 = %(:a :b """string with " escaped quote marks""" .)
         serialize(n3, nil, [/string with \\" escaped quote mark/])
       end
+
+      it "encodes embedded \\" do
+        n3 = %(:a :b """string with \\ escaped quote marks""" .)
+        serialize(n3, nil, [/string with \\\\ escaped quote mark/])
+      end
+
+      it "encodes embedded \\ multi-line" do
+        n3 = %(:a :b """string with \\ escaped quote marks
+  """ .)
+        serialize(n3, nil, [/string with \\\\ escaped quote mark/])
+      end
     end
     
     describe "with language" do


### PR DESCRIPTION
Thanks for this repo! There is one problem though. According to the [n3 spec](https://www.w3.org/TeamSubmission/n3/#strings), backslashes should be escaped. This works for single-line literals, but not for multi-line. This PR fixes this issue.